### PR TITLE
fix(onboarding): the installation command publishes the agent initialisation file

### DIFF
--- a/src/Commands/ForestInstall.php
+++ b/src/Commands/ForestInstall.php
@@ -23,8 +23,12 @@ class ForestInstall extends Command
 
         $this->call('vendor:publish', [
             '--provider' => ForestServiceProvider::class,
-            '--tag'      => 'forest',
             '--tag'      => 'config',
+        ]);
+
+        $this->call('vendor:publish', [
+            '--provider' => ForestServiceProvider::class,
+            '--tag'      => 'forest',
         ]);
     }
 


### PR DESCRIPTION
This PR fixes an issue with the installation command.

The `forest_admin.php` initialisation file is now correctly published when the command is run.
